### PR TITLE
add missing pyproject-build CLI

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About python-build
-==================
+About python-build-feedstock
+============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/python-build-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/pypa/build
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/python-build-feedstock/blob/main/LICENSE.txt)
 
 Summary: A simple, correct PEP 517 build frontend
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package license: MIT
 
 Summary: A simple, correct PEP 517 build frontend
 
+Documentation: https://pypa-build.readthedocs.io
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ about:
   license: MIT
   license_file: LICENSE
   summary: A simple, correct PEP 517 build frontend
+  doc_url: https://pypa-build.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,11 @@ source:
   sha256: d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - python-build = build.__main__:entrypoint
+    - pyproject-build = build.__main__:entrypoint
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -37,6 +38,7 @@ test:
   commands:
     - pip check
     - python-build --help
+    - pyproject-build --help
   requires:
     - pip
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- adds the upstream-declarted [`entry-points.script`](https://github.com/pypa/build/blob/0.10.0/pyproject.toml#L73)
  - `pyproject-build` was still getting created by `flit` or whatever, but not functional on windows
- adds `doc_url` 